### PR TITLE
strategy.js: check both profileURL and profileUrl

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -49,7 +49,7 @@ function Strategy(options, verify) {
   options.authorizationURL = options.authorizationURL || 'https://slack.com/oauth/authorize';
   options.scope = options.scope || ['identity.basic', 'identity.email', 'identity.avatar', 'identity.team'];
 
-  this.profileUrl = options.profileUrl || "https://slack.com/api/users.identity"; // requires 'identity.basic' scope
+  this.profileUrl = options.profileURL || options.profileUrl || "https://slack.com/api/users.identity"; // requires 'identity.basic' scope
   this._team = options.team;
 
   OAuth2Strategy.call(this, options, verify);


### PR DESCRIPTION
Other endpoint names end with URL, thus it makes sense to treat profile url the same.